### PR TITLE
Fix max-issues-per-linter variable name in example

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -236,7 +236,7 @@ issues:
   exclude-use-default: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0


### PR DESCRIPTION
.golangci.example.yml has wrong name for `max-issues-per-linter` variable